### PR TITLE
Fix - Removing return type that used int typing

### DIFF
--- a/builder/formatter.ts
+++ b/builder/formatter.ts
@@ -158,6 +158,8 @@ const formatModuleName = (m: string) => {
             case "Object.<string,function()>":
             case "Object.<string,string>":
                 return "Map<any, any>"
+            case "{type:string,index:int}":
+                return "{ type: string, index: number }"
             default:
                 return m
         }


### PR DESCRIPTION
Adding conditional to replace wrong typing:

![image](https://user-images.githubusercontent.com/13325346/65992924-8fb03e00-e466-11e9-837a-9cf4d1fd443a.png)
